### PR TITLE
add iri's to JSON output

### DIFF
--- a/components/EntityLinker.py
+++ b/components/EntityLinker.py
@@ -16,7 +16,9 @@ def GetAllEntities(entityMentions):
                     name=entity["name"],
                     startIndex=entity["startIndex"],
                     endIndex=entity["endIndex"],
-                    fileName=fileName,
+                    sentence=sentence["sentence"],
+                    sentenceStartIndex=sentence["sentenceStartIndex"],
+                    sentenceEndIndex=sentence["sentenceEndIndex"],
                 )
                 allEntities.append(newEntity)
     return allEntities

--- a/components/GetSpacyData.py
+++ b/components/GetSpacyData.py
@@ -95,7 +95,7 @@ def BuildJSONFromEntities(entities: List[EntityLinked], doc, fileName: str):
         currentJson.append(final_json)
     return currentJson
 
-def GetEntities(doc):
+def GetEntities(doc) -> List[Entity]:
     entities = []
     for entity in doc.ents:
         entities.append(

--- a/lib/Entity.py
+++ b/lib/Entity.py
@@ -1,15 +1,8 @@
 class Entity:
-    def __init__(self, name, startIndex, endIndex, fileName):
+    def __init__(self, name: str, startIndex: int, endIndex: int, sentence: str, sentenceStartIndex: int, sentenceEndIndex: int):
         self.name = name
         self.startIndex = startIndex
         self.endIndex = endIndex
-        self.fileName = fileName
-    
-    #Not used - previously required appending, which was hard/unnecessary to implement
-    def getEntity(self):
-        return {
-            "name": self.name,
-            "startIndex": self.startIndex,
-            "endIndex": self.endIndex,
-            "fileName": self.fileName,
-        }
+        self.sentence = sentence
+        self.sentenceStartIndex = sentenceStartIndex
+        self.sentenceEndIndex = sentenceEndIndex

--- a/lib/EntityLinked.py
+++ b/lib/EntityLinked.py
@@ -4,6 +4,15 @@ from lib.Entity import Entity
 class EntityLinked(Entity):
     def __init__(self, entity, iri):
         super().__init__(
-            entity.name, entity.startIndex, entity.endIndex, entity.fileName
+            entity.name, entity.startIndex, entity.endIndex, entity.sentence, entity.sentenceStartIndex, entity.sentenceEndIndex
         )
         self.iri = iri.replace(" ", "_")
+
+    def getEntityJSON(self):
+        return {
+            "name": self.name,
+            "startIndex": self.startIndex,
+            "endIndex": self.endIndex,
+            "iri": "knox-kb01.srv.aau.dk/" + self.iri,
+        }
+

--- a/lib/EntityLinked.py
+++ b/lib/EntityLinked.py
@@ -2,7 +2,7 @@ from lib.Entity import Entity
 
 
 class EntityLinked(Entity):
-    def __init__(self, entity, iri):
+    def __init__(self, entity: Entity, iri: str):
         super().__init__(
             entity.name, entity.startIndex, entity.endIndex, entity.sentence, entity.sentenceStartIndex, entity.sentenceEndIndex
         )

--- a/main.py
+++ b/main.py
@@ -78,9 +78,10 @@ async def main():
     except UndetectedLanguageException:
         raise HTTPException(status_code=400, detail="Undetected language")
 
-    entsJSON = GetSpacyData.GetEntities(
-        doc, "Artikel.txt"
-    )  # appends entities in list
+    ents = GetSpacyData.GetEntities(
+        doc
+    )  # construct entities from text
+
     # To prevent appending challenges, the final JSON is created in GetEntities()
     # entMentions= GetSpacyData.entityMentionJson(ents)  #Returns JSON object containing an array of entity mentions
     await Db.InitializeIndexDB(
@@ -88,7 +89,14 @@ async def main():
     )  # makes the DB containing the entities of KG
     # Returns JSON object containing an array of entity links
     entLinks = await entitylinkerFunc(
-        GetAllEntities(entsJSON)
+        ents
     )  # Returns JSON object containing an array of entity links
+
+    entsJSON = GetSpacyData.BuildJSONFromEntities(
+        entLinks,
+        doc,
+        "Artikel.txt"
+    )
+
     with open("entity_mentions.json", "w", encoding="utf8") as entityJson:
         json.dump(entsJSON, entityJson, ensure_ascii=False, indent=4)

--- a/tests/unit/test_EntityLinker.py
+++ b/tests/unit/test_EntityLinker.py
@@ -27,8 +27,8 @@ async def test_entitylinkerFunc():
         ):
             # Create some Entity instances
             entMentions = [
-                Entity("Entity1", 0, 6, "file1"),
-                Entity("newEntity3", 0, 6, "file2"),
+                Entity("Entity1", 0, 6, "Sentence1", 0, 9),
+                Entity("newEntity3", 0, 6, "Sentence2", 0, 9),
             ]
 
             # Call the entitylinkerFunc
@@ -62,7 +62,7 @@ async def test_entitylinkerFuncFindsCandidatesThatStartWithE():
         ):
             # Create some Entity instances
             entMentions = [
-                Entity("Entity1", 0, 6, "file1"),
+                Entity("Entity1", 0, 6, "Sentence1", 0, 9),
             ]
 
             # Call the entitylinkerFunc
@@ -95,7 +95,7 @@ async def test_CheckIfSpaceHasBeenReplacedWithUnderscore():
         ):
             # Create some Entity instances
             entMentions = [
-                Entity("Entity1", 0, 6, "file1"),
+                Entity("Entity1", 0, 6, "Sentence1", 0, 9),
             ]
 
             # Call the entitylinkerFunc
@@ -149,7 +149,7 @@ async def test_entitylinkeraccuracy():
             # Create some Entity instances
             TestingDataset = {
                 "test": [
-                    Entity(name, 0, 6, "file")
+                    Entity(name, 0, 6, "Sentence1", 0, 9)
                     for name in names_with_duplicates
                 ],
                 "GoldStandardNames": [

--- a/tests/unit/test_GetSpacyData.py
+++ b/tests/unit/test_GetSpacyData.py
@@ -1,9 +1,12 @@
 import sys
 import pytest
 
+from lib import EntityLinked
+
 sys.path.append(".")
 from components import GetSpacyData
 from lib.Entity import Entity
+from lib.EntityLinked import EntityLinked
 
 
 # Test that GetText returns the correct text from the file
@@ -35,6 +38,7 @@ def test_GetTokens():
 
 
 # Testing that GetEntities returns all entities and their indexes
+@pytest.mark.asyncio
 def test_GetEntities():
     docFile = type('obj', (object,), {
         "ents": [
@@ -65,20 +69,37 @@ def test_GetEntities():
 
     # Ensure the structure of docFile matches the expected format
 
-    entities = GetSpacyData.GetEntities(docFile, filename)
-    testIndex = None
-    for i in range(len(entities)):
-        if entities[i]["fileName"] == "Testing2023":
+    entities = GetSpacyData.GetEntities(docFile)
+
+    entLinks = []
+    for entity in entities:
+        entLinks.append(
+            EntityLinked(
+                entity,
+                "knox.aau.dk/some_iri"
+            )
+        )
+
+    entsJSON = GetSpacyData.BuildJSONFromEntities(
+        entLinks,
+        docFile,
+        filename
+    )
+
+    testIndex = 0
+    for i in range(len(entsJSON)):
+        if entsJSON[i]["fileName"] == "Testing2023":
             testIndex = i
             break
-    assert entities[testIndex]["sentences"][0]["sentence"] == "Drake is a music artist"
-    assert entities[testIndex]["sentences"][0]["entityMentions"][0]["name"] == "Drake"
-    assert entities[testIndex]["sentences"][0]["entityMentions"][0]["startIndex"] == 0
-    assert entities[testIndex]["sentences"][0]["entityMentions"][0]["endIndex"] == 5
-    assert entities[testIndex]["fileName"] == "Testing2023"
 
-    assert entities[testIndex]["sentences"][1]["sentence"] == "Hello Buddyguy"
-    assert entities[testIndex]["sentences"][1]["entityMentions"][0]["name"] == "Buddyguy"
-    assert entities[testIndex]["sentences"][1]["entityMentions"][0]["startIndex"] == 6
-    assert entities[testIndex]["sentences"][1]["entityMentions"][0]["endIndex"] == 14
-    assert entities[testIndex]["fileName"] == "Testing2023"
+    assert entsJSON[testIndex]["sentences"][0]["sentence"] == "Drake is a music artist" 
+    assert entsJSON[testIndex]["sentences"][0]["entityMentions"][0]["name"] == "Drake"
+    assert entsJSON[testIndex]["sentences"][0]["entityMentions"][0]["startIndex"] == 0
+    assert entsJSON[testIndex]["sentences"][0]["entityMentions"][0]["endIndex"] == 5
+    assert entsJSON[testIndex]["fileName"] == "Testing2023"
+
+    assert entsJSON[testIndex]["sentences"][1]["sentence"] == "Hello Buddyguy"
+    assert entsJSON[testIndex]["sentences"][1]["entityMentions"][0]["name"] == "Buddyguy"
+    assert entsJSON[testIndex]["sentences"][1]["entityMentions"][0]["startIndex"] == 6
+    assert entsJSON[testIndex]["sentences"][1]["entityMentions"][0]["endIndex"] == 14
+    assert entsJSON[testIndex]["fileName"] == "Testing2023"


### PR DESCRIPTION
- Restructure `GetEntities`: It now returns a list of Entity instead of building the JSON as well
- Added `BuildJSONFromEntities` function
- Add additional info to entity class including _sentence_, _sentenceStartindex_ and _sentenceEndIndex_
- Move `.getEntityJSON` from **Entity** to **EntityLinked**
- Updated tests after changes in **Entity** and **EntityLinked**
- Prepend URI to IRI's (knox-kb01.srv.aau.dk/) closes #61 